### PR TITLE
Fix remote debugging with PyCharm

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,39 @@ ExTreeMaker
   * Remember to *branch before committing anything*: ```git checkout -b my-new-branch```
   * The ```setup.sh``` script took care of adding ```origin``` as your own repo, so to push just do the usual ```git push origin my-new-branch```
 
+
+# PyCharm configuration
+
+## Deployment
+
+This steps indicate to PyCharm how-to copy your local files to ingrid. Go to File > Settings > Build, Execution, Deployment
+and then click on Deployment. Click on the green plus button to add a new deployment configuration. Name it ``ingrid`` and choose ``SFTP`` as type.
+
+On the Connection tab, set:
+
+* SFTP host: ingrid-ui1.cism.ucl.ac.be
+* Port: 22
+* Username: your ingrid username
+* Auth type: if you have an SSH key, you can choose 'Key pair' here, or password otherwise
+* If you chose 'Key pair', fill the 'Private key file' field with the absolute path of your private SSH key, and the 'passphrase' field. If you chose password, fill the password field.
+
+On the Mappings tab, set the 'Deployment path' to the absolute path of the ``ExTreeMaker`` directory inside the CMSSW release. For example, it can be ``/home/fynu/sbrochet/scratch/Framework/CMSSW_7_4_4/src/cp3-llbb/ExTreeMaker``
+
+Click on 'Apply' to save your changes.
+
+## Remote python interpreter
+
+We need to configure PyCharm to use python from CMSSW instead of system-wide python. Go to File > Settings > Project: ExTreeMaker and click on 'Project Interpreter'. Click on the little wheel (top right of the screen), and choose 'Add remote'.
+
+Select 'Deployment configuration', and choose 'ingrid' (or whatever name you used for your deployment configuration). For the 'Python interpreter path', select the ``python`` file located in the ``bin`` folder of the framework. It'll look like ``/home/fynu/sbrochet/scratch/Framework/CMSSW_7_4_4/src/cp3-llbb/ExTreeMaker/bin/python``. Click on OK to validate. Make sure that the new python interpreter is selected.
+
+## Run configuration
+
+Final step is to tell PyCharm how-to execute the framework on ingrid. Go to Run > Edit configurations... Click on the green plus button and choose 'Python'. Name your new run configuration as you want (ingrid for example...). In the configuration tab, set:
+
+* Script: click on the '...' button to browse. Select the file 'python/PatAnalysis/ControlPlots.py'
+* Script parameters: ``-c incConfig --all -i /home/fynu/obondu/storage/MINIAODSIM/RelValTTbar_13_PU25ns_MCRUN2_74_V9_gensim71X-v1.root --nEvents 100`` will allow you to get started
+* Python interpreter: choose here your remote interpreter (something like ``sftp://...``)
+* Working directory: Browse and choose the 'python' folder
+
+That's all. Click on Apply and then OK. You can now run remotely on ingrid. To test, click on the green arrow (top right of the screen). Be sure first to select the right run configuration on the drop-down list on the left of the run button. You should see the output inside the Run window.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ ExTreeMaker
 
 # PyCharm configuration
 
+You need the professional edition of PyCharm. You can request a licence using your UCL mail address here: https://www.jetbrains.com/student
+
+## Project setup
+
+Launch PyCharm. On the welcome screen, choose 'Checkout from Version Control' and select Github. Follow the instructions, and checkout **your** fork of ``ExTreeMaker``.
+
 ## Deployment
 
 This steps indicate to PyCharm how-to copy your local files to ingrid. Go to File > Settings > Build, Execution, Deployment
@@ -52,9 +58,15 @@ On the Connection tab, set:
 * Auth type: if you have an SSH key, you can choose 'Key pair' here, or password otherwise
 * If you chose 'Key pair', fill the 'Private key file' field with the absolute path of your private SSH key, and the 'passphrase' field. If you chose password, fill the password field.
 
-On the Mappings tab, set the 'Deployment path' to the absolute path of the ``ExTreeMaker`` directory inside the CMSSW release. For example, it can be ``/home/fynu/sbrochet/scratch/Framework/CMSSW_7_4_4/src/cp3-llbb/ExTreeMaker``
+On the Mappings tab, set the 'Deployment path' to the absolute path of the ``ExTreeMaker`` directory inside the CMSSW release. For example, it can be ``/home/fynu/sbrochet/scratch/Framework/CMSSW_7_4_4/src/cp3-llbb/ExTreeMaker``.
+
+Now click on the 'Add another mapping'. For the local path, set the absolute path of the ``ExTreeMaker`` directory. For the deployment path, use the same path as above, but replace ``src`` by ``python`` (for example, ``/home/fynu/sbrochet/scratch/Framework/CMSSW_7_4_4/python/cp3-llbb/ExTreeMaker``). Set the web path to '/'.
 
 Click on 'Apply' to save your changes.
+
+Now, on the menu on the left, click on 'Options' under 'Deployment'. Set the option 'Upload changed files automatically to the default server' to 'Always'. Click on 'Apply' to save your changes, and 'OK' to close the dialog.
+
+Now you need to do the first upload of the project remotely. On the 'Project' window, right-click on the 'ExTreeMaker' project (top left of the screen), and select 'Upload to ingrid'.
 
 ## Remote python interpreter
 

--- a/bin/python
+++ b/bin/python
@@ -1,8 +1,17 @@
 #!/bin/sh
+
 source /cvmfs/cms.cern.ch/cmsset_default.sh
-# todo: please do not delete the commented 'cd' yet, they still may be needed for pycharm debug mode
-#cd CMSSW_BASE/src/
+
+# When debugging, PyCharm first execute some python command to open a socket on the remote host.
+# In this step, the working directory is not set. We need to cd into a CMSSW area manually
+
+# Get script directory
+DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+
+pushd $DIR 2&> /dev/null
 eval `/cvmfs/cms.cern.ch/common/scramv1 ru -sh`
-#'cd' -
+popd 2&> /dev/null
+
 export PYTHONPATH="${PYTHONPATH}:." #TODO: fix this some day
-python $@
+
+python "$@"


### PR DESCRIPTION
As the title says, this fix remote debugging with PyCharm.

The only missing piece was the quotes around `$@`. In details, when launching remote debugging, PyCharm first execute python with these arguments:

```
-c import socket; s = socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); s.bind(('', 0)); print(s.getsockname()); s.close()
```

This creates a socket on remote host in order to launch debugging. For this step, unfortunately, remote working directory is not set, so we need to `cd` manually to a valid CMSSW area.

README is also updated with instructions on how-to setup PyCharm. Can and I guess must be improved :)
