### PR TITLE
Speed-up PyCharm parsing of remote libraries

### DIFF
--- a/bin/python
+++ b/bin/python
@@ -12,6 +12,12 @@ pushd $DIR 2&> /dev/null
 eval `/cvmfs/cms.cern.ch/common/scramv1 ru -sh`
 popd 2&> /dev/null
 
-export PYTHONPATH="${PYTHONPATH}:." #TODO: fix this some day
+PYTHONPATH="${PYTHONPATH}:." #TODO: fix this some day
+
+# Remove the CMSSW/lib/ path from $PYTHONPATH. It's not needed for our framework and speed-up (a lot!) the PyCharm parsing process
+PYTHONPATH=${PYTHONPATH//${CMSSW_BASE}\/lib\/${SCRAM_ARCH}:/}
+PYTHONPATH=${PYTHONPATH//${CMSSW_RELEASE_BASE}\/lib\/${SCRAM_ARCH}:/}
+
+export PYTHONPATH
 
 python "$@"


### PR DESCRIPTION
PyCharm scan all the paths in $PYTHONPATH, looking for python libraries to parse for auto-completion. It also looks for .so file in case of it's a compiled library.

When doing a cmsenv, the CMSSW/lib/ folders are also added to the $PYTHONPATH. As a result, PyCharm takes ages to do its initial parsing because it has to scan for hundred of libraries which we know for sure are **not** python library.

This commit removes the CMSSW/lib paths from PYTHONPATH (both for local release as well as base release). Initial parsing time for PyCharm is reduced from about 1 hour to 1 minute.
