### PR TITLE
Small refactoring

### DIFF
--- a/python/Core/Analyzer.py
+++ b/python/Core/Analyzer.py
@@ -7,7 +7,6 @@ class Analyzer(Runnable):
 
     def __init__(self, **kwargs):
         Runnable.__init__(self)
-        self._producers = []
 
     def analyze(self, event, products):
         """
@@ -18,15 +17,3 @@ class Analyzer(Runnable):
         :return:
         """
         raise NotImplementedError()
-
-    def runs(self, clazz, name):
-        """
-        Inform the framework to run the producer clazz before the analyzer
-        :param clazz: The class name of the Producer
-        :param name: The name of the Producer. Tree branches will be prefixed by this name
-        :return:
-        """
-
-        producer = clazz(name=name)
-
-        self._producers.append(producer)

--- a/python/Core/Configuration.py
+++ b/python/Core/Configuration.py
@@ -6,7 +6,7 @@ class Bunch:
     def __init__(self, **kwds):
         self.__dict__.update(kwds)
 
-Collection = namedtuple('Collection', 'alias type input_tag')
+Collection = namedtuple('Collection', 'name type input_tag')
 
 class Configuration:
 

--- a/python/Core/Configuration.py
+++ b/python/Core/Configuration.py
@@ -2,8 +2,11 @@ __author__ = 'sbrochet'
 
 from collections import namedtuple
 
-class Bunch:
-    def __init__(self, **kwds):
+class Producer:
+    def __init__(self, name, clazz, prefix, **kwds):
+        self.name = name
+        self.clazz = clazz
+        self.prefix = prefix
         self.__dict__.update(kwds)
 
 Collection = namedtuple('Collection', 'name type input_tag')

--- a/python/Core/Configuration.py
+++ b/python/Core/Configuration.py
@@ -9,6 +9,15 @@ class Producer:
         self.prefix = prefix
         self.__dict__.update(kwds)
 
+    def clone(self, **kwargs):
+        params = self.__dict__.copy()
+        params.update(kwargs)
+
+        return self.__class__(**params)
+
+    def __str__(self):
+        return 'Producer %r:%r -> %r' % (self.name, self.prefix, self.clazz)
+
 Collection = namedtuple('Collection', 'name type input_tag')
 
 class Configuration:

--- a/python/Core/ProductManager.py
+++ b/python/Core/ProductManager.py
@@ -5,14 +5,21 @@ class ProductManager:
     class ProductWrapper:
 
         def __init__(self, prefix, instance):
-            self._prefix = prefix
-            self._instance = instance
+            # Use __dict__ to avoid a call to __setattr__
+            self.__dict__['_prefix'] = prefix
+            self.__dict__['_instance'] = instance
 
         def __getattr__(self, item):
             if not item.startswith(self._prefix):
                 item = self._prefix + item
 
             return self._instance.__getattr__(item)
+
+        def __setattr__(self, item, value):
+            if not item.startswith(self._prefix):
+                item = self._prefix + item
+
+            return self._instance.__setattr__(item, value)
 
     def __init__(self, products):
         for product in products:

--- a/python/Core/Runnable.py
+++ b/python/Core/Runnable.py
@@ -1,6 +1,7 @@
 __author__ = 'sbrochet'
 
 from pytree import TreeModel
+from Configuration import Collection
 
 class Runnable:
     """Base class for Analyzers and Producers"""
@@ -31,7 +32,7 @@ class Runnable:
         :param inputTag: The edm::InputTag of the collection
         :return:
         """
-        self._collections.append({'name': name, 'type': type, 'input_tag': inputTag})
+        self._collections.append(Collection(name=name, type=type, input_tag=inputTag))
 
     def produces(self, clazz, name, prefix):
         """

--- a/python/Models/Event.py
+++ b/python/Models/Event.py
@@ -1,0 +1,28 @@
+__author__ = 'sbrochet'
+
+from pytree import TreeModel
+from pytree import FloatCol, ULongCol, IntCol
+
+from ROOT import std
+
+class Event(TreeModel):
+    run = ULongCol()
+    lumi = ULongCol()
+    event = ULongCol()
+
+    rho = FloatCol()
+
+    npu = IntCol()
+    true_interactions = FloatCol()
+
+    pt_hat = FloatCol()
+    weight = FloatCol(default=1)
+
+    alpha_QCD = FloatCol()
+    alpha_QED = FloatCol()
+    q_scale = FloatCol()
+    pdf_id = std.pair('int, int')
+    pdf_x = std.pair('float, float')
+
+    n_ME_partons = IntCol()
+    n_ME_partons_filtered = IntCol()

--- a/python/Producers/Electrons.py
+++ b/python/Producers/Electrons.py
@@ -1,5 +1,8 @@
 __author__ = 'obondu'
 
+from Tools import parse_effective_areas_file
+
+import Core.Configuration
 import Models.Electrons
 from Producer import Producer
 from Producers.Helper import fill_candidate, fill_isolations
@@ -33,3 +36,11 @@ class Electrons(Producer):
             fill_isolations(electron, "R04", electron.chargedHadronIso(), electron.neutralHadronIso(),
                                 electron.photonIso(), electron.puChargedHadronIso(), rho, eta,
                                 self._effective_areas_R04, product)
+
+
+_electron_effective_areas = parse_effective_areas_file("RecoEgamma/ElectronIdentification/data/PHYS14/"
+                                                       "effAreaElectrons_cone03_pfNeuHadronsAndPhotons.txt")
+
+default_configuration = Core.Configuration.Producer(name='electrons', clazz=Electrons, prefix='electron_',
+                                                    electron_collection='slimmedElectrons',
+                                                    effective_areas_R03=_electron_effective_areas)

--- a/python/Producers/Event.py
+++ b/python/Producers/Event.py
@@ -1,0 +1,53 @@
+__author__ = 'sbrochet'
+
+from Producers.Producer import Producer
+
+import Models.Event
+
+class Event(Producer):
+    # noinspection PyUnusedLocal
+    def __init__(self, name, prefix, **kwargs):
+        Producer.__init__(self, name)
+
+        self.uses('puInfo', 'std::vector<PileupSummaryInfo>', 'addPileupInfo')
+        self.uses('genInfo', 'GenEventInfoProduct', 'generator')
+        self.uses('rho', 'double', 'fixedGridRhoFastjetAll')
+
+        self.produces(Models.Event.Event, name, prefix)
+
+    def produce(self, event, products):
+
+        product = getattr(products, self._name)
+
+        product.run = event.run()
+        product.lumi = event.lumi()
+        product.event = event.event()
+
+        product.rho = event.rho[0]
+
+        # Generator information
+        if event.genInfo:
+            if event.genInfo.hasBinningValues():
+                product.pt_hat = event.genInfo.binningValues()[0]
+
+            product.weight = event.genInfo.weight()
+
+            product.n_ME_partons = event.genInfo.nMEPartons()
+            product.n_ME_partons_filtered = event.genInfo.nMEPartonsFiltered()
+
+            product.alpha_QCD = event.genInfo.alphaQCD()
+            product.alpha_QED = event.genInfo.alphaQED()
+            product.q_scale = event.genInfo.qScale()
+
+            if event.genInfo.hasPDF():
+                product.pdf_id = event.genInfo.pdf().id
+                product.pdf_x.first = event.genInfo.pdf().x.first
+                product.pdf_x.second = event.genInfo.pdf().x.second
+
+        if event.puInfo:
+            for puInfo in event.puInfo:
+                if puInfo.getBunchCrossing() != 0:
+                    continue
+
+                product.npu = puInfo.getPU_NumInteractions()
+                product.true_interactions = puInfo.getTrueNumInteractions()

--- a/python/Producers/Event.py
+++ b/python/Producers/Event.py
@@ -2,6 +2,7 @@ __author__ = 'sbrochet'
 
 from Producers.Producer import Producer
 
+import Core.Configuration
 import Models.Event
 
 class Event(Producer):
@@ -51,3 +52,5 @@ class Event(Producer):
 
                 product.npu = puInfo.getPU_NumInteractions()
                 product.true_interactions = puInfo.getTrueNumInteractions()
+
+default_configuration = Core.Configuration.Producer(name='event', prefix='event_', clazz=Event)

--- a/python/Producers/Jets.py
+++ b/python/Producers/Jets.py
@@ -3,6 +3,8 @@ __author__ = 'sbrochet'
 import Models.Jets
 from Producer import Producer
 
+import Core.Configuration
+
 from Helper import fill_candidate
 
 from ROOT import std
@@ -37,3 +39,6 @@ class Jets(Producer):
                 btaggers[btagger] = jet.bDiscriminator(btagger)
 
             product.btag.push_back(btaggers)
+
+default_configuration = Core.Configuration.Producer(name='jets', clazz=Jets, prefix='jet_',
+        jet_collection='slimmedJets', btag_collections=['pfCombinedInclusiveSecondaryVertexV2BJetTags'])

--- a/python/Producers/METs.py
+++ b/python/Producers/METs.py
@@ -1,11 +1,12 @@
 __author__ = 'obondu'
 
+import Core.Configuration
 import Models.METs
 from Producer import Producer
 from Producers.Helper import fill_candidate
 
-class METs(Producer):
 
+class METs(Producer):
     def __init__(self, name, prefix, met_collection):
         Producer.__init__(self, name)
 
@@ -17,3 +18,7 @@ class METs(Producer):
         product = getattr(products, self._name)
         for met in mets:
             fill_candidate(met, product)
+
+
+default_configuration = Core.Configuration.Producer(name='mets', clazz=METs, prefix='met_',
+                                                    met_collection='slimmedMETs')

--- a/python/Producers/Muons.py
+++ b/python/Producers/Muons.py
@@ -1,5 +1,8 @@
 __author__ = 'obondu'
 
+from Tools import parse_effective_areas_file
+
+import Core.Configuration
 import Models.Muons
 from Producer import Producer
 from Producers.Helper import fill_candidate, fill_isolations
@@ -37,3 +40,15 @@ class Muons(Producer):
             pfIso = muon.pfIsolationR04()
             fill_isolations(muon, "R04", pfIso.sumChargedHadronPt, pfIso.sumNeutralHadronEt,
                                 pfIso.sumPhotonEt, pfIso.sumPUPt, rho, muon.eta(), self._effective_areas_R04, product)
+
+
+_muon_effective_areas_R03 = parse_effective_areas_file("cp3_llbb/ExTreeMaker/data/"
+                                                       "effAreaMuons_cone03_pfNeuHadronsAndPhotons.txt")
+_muon_effective_areas_R04 = parse_effective_areas_file("cp3_llbb/ExTreeMaker/data/"
+                                                       "effAreaMuons_cone04_pfNeuHadronsAndPhotons.txt")
+
+default_configuration = Core.Configuration.Producer(name='muons', clazz=Muons, prefix='muon_',
+                                                    muon_collection='slimmedMuons',
+                                                    vertex_collection='offlineSlimmedPrimaryVertices',
+                                                    effective_areas_R03=_muon_effective_areas_R03,
+                                                    effective_areas_R04=_muon_effective_areas_R04)

--- a/python/Producers/Vertices.py
+++ b/python/Producers/Vertices.py
@@ -5,12 +5,14 @@ from Producer import Producer
 
 class Vertices(Producer):
 
-    def __init__(self, name, vertex_collection):
+    def __init__(self, name, prefix, vertex_collection):
         Producer.__init__(self, name)
 
-        self.uses('vertices', 'std::vector<reco::Vertex>', vertex_collection)
-        self.produces(Models.Vertices.Vertices, 'vertices', 'vertex_')
+        self.uses(name, 'std::vector<reco::Vertex>', vertex_collection)
+        self.produces(Models.Vertices.Vertices, name, prefix)
 
     def produce(self, event, products):
-        for vertex in event.vertices:
-            products.vertices.vertex_position.push_back(vertex.position())
+        vertices = getattr(event, self._name)
+        product = getattr(products, self._name)
+        for vertex in vertices:
+            product.position.push_back(vertex.position())

--- a/python/Producers/Vertices.py
+++ b/python/Producers/Vertices.py
@@ -1,10 +1,11 @@
 __author__ = 'obondu'
 
+import Core.Configuration
 import Models.Vertices
 from Producer import Producer
 
-class Vertices(Producer):
 
+class Vertices(Producer):
     def __init__(self, name, prefix, vertex_collection):
         Producer.__init__(self, name)
 
@@ -16,3 +17,7 @@ class Vertices(Producer):
         product = getattr(products, self._name)
         for vertex in vertices:
             product.position.push_back(vertex.position())
+
+
+default_configuration = Core.Configuration.Producer(name='vertices', prefix='vertex_', clazz=Vertices,
+                                                    vertex_collection='offlineSlimmedPrimaryVertices')

--- a/python/TestConfiguration.py
+++ b/python/TestConfiguration.py
@@ -4,6 +4,7 @@ from Core.Configuration import Configuration, Bunch, Collection
 from Tools import parse_effective_areas_file
 
 from TestAnalyzer import TestAnalyzer
+from Producers.Event import Event
 from Producers.Vertices import Vertices
 from Producers.Jets import Jets
 from Producers.Muons import Muons
@@ -24,6 +25,7 @@ class TestConfiguration(Configuration):
                                                           "effAreaMuons_cone04_pfNeuHadronsAndPhotons.txt")
 
     producers = [
+        Bunch(alias='event', prefix='event_', clazz=Event),
         Bunch(alias='vertices', clazz=Vertices, vertex_collection='offlineSlimmedPrimaryVertices'),
         Bunch(alias='jets', clazz=Jets, prefix='jet_', jet_collection='slimmedJets',
               btag_collections=['pfCombinedInclusiveSecondaryVertexV2BJetTags']),

--- a/python/TestConfiguration.py
+++ b/python/TestConfiguration.py
@@ -39,11 +39,11 @@ class TestConfiguration(Configuration):
     ]
 
     collections = [
-        Collection(alias='vertices', type='std::vector<reco::Vertex>', input_tag='offlineSlimmedPrimaryVertices'),
-        Collection(alias='jets', type='std::vector<pat::Jet>', input_tag='slimmedJets'),
-        Collection(alias='muons', type='std::vector<pat::Muon>', input_tag='slimmedMuons'),
-        Collection(alias='electrons', type='std::vector<pat::Electron>', input_tag='slimmedElectrons'),
-        Collection(alias='mets', type='std::vector<pat::MET>', input_tag='slimmedMETs')
+        Collection(name='vertices', type='std::vector<reco::Vertex>', input_tag='offlineSlimmedPrimaryVertices'),
+        Collection(name='jets', type='std::vector<pat::Jet>', input_tag='slimmedJets'),
+        Collection(name='muons', type='std::vector<pat::Muon>', input_tag='slimmedMuons'),
+        Collection(name='electrons', type='std::vector<pat::Electron>', input_tag='slimmedElectrons'),
+        Collection(name='mets', type='std::vector<pat::MET>', input_tag='slimmedMETs')
     ]
 
     analyzer_configuration = {

--- a/python/TestConfiguration.py
+++ b/python/TestConfiguration.py
@@ -1,41 +1,33 @@
 __author__ = 'sbrochet'
 
-from Core.Configuration import Configuration, Producer, Collection
-from Tools import parse_effective_areas_file
+from Core.Configuration import Configuration, Collection
 
 from TestAnalyzer import TestAnalyzer
-from Producers.Event import Event
-from Producers.Vertices import Vertices
-from Producers.Jets import Jets
-from Producers.Muons import Muons
-from Producers.Electrons import Electrons
-from Producers.METs import METs
+
+import Producers.Event
+import Producers.Vertices
+import Producers.Jets
+import Producers.Muons
+import Producers.Electrons
+import Producers.METs
 
 
 class TestConfiguration(Configuration):
 
     analyzer = TestAnalyzer
 
-    electron_effective_areas = parse_effective_areas_file("RecoEgamma/ElectronIdentification/data/PHYS14/"
-                                                          "effAreaElectrons_cone03_pfNeuHadronsAndPhotons.txt")
-
-    muon_effective_areas_R03 = parse_effective_areas_file("cp3_llbb/ExTreeMaker/data/"
-                                                          "effAreaMuons_cone03_pfNeuHadronsAndPhotons.txt")
-    muon_effective_areas_R04 = parse_effective_areas_file("cp3_llbb/ExTreeMaker/data/"
-                                                          "effAreaMuons_cone04_pfNeuHadronsAndPhotons.txt")
-
     producers = [
-        Producer(name='event', prefix='event_', clazz=Event),
-        Producer(name='vertices', clazz=Vertices, vertex_collection='offlineSlimmedPrimaryVertices'),
-        Producer(name='jets', clazz=Jets, prefix='jet_', jet_collection='slimmedJets',
-              btag_collections=['pfCombinedInclusiveSecondaryVertexV2BJetTags']),
-        Producer(name='puppiJets', clazz=Jets, prefix='puppijet_', jet_collection='slimmedJetsPuppi'),
-        Producer(name='muons', clazz=Muons, prefix='muon_', muon_collection='slimmedMuons',
-              vertex_collection='offlineSlimmedPrimaryVertices', effective_areas_R03=muon_effective_areas_R03,
-              effective_areas_R04=muon_effective_areas_R04),
-        Producer(name='electrons', clazz=Electrons, prefix='electron_', electron_collection='slimmedElectrons',
-              effective_areas_R03=electron_effective_areas),
-        Producer(name='mets', clazz=METs, prefix='met_', met_collection='slimmedMETs')
+        Producers.Event.default_configuration,
+        Producers.Vertices.default_configuration,
+        Producers.Jets.default_configuration,
+        Producers.Jets.default_configuration.clone(
+            name='puppiJets',
+            prefix='puppijet_',
+            jet_collection='slimmedJetsPuppi'
+        ),
+        Producers.Muons.default_configuration,
+        Producers.Electrons.default_configuration,
+        Producers.METs.default_configuration
     ]
 
     collections = [

--- a/python/TestConfiguration.py
+++ b/python/TestConfiguration.py
@@ -1,6 +1,6 @@
 __author__ = 'sbrochet'
 
-from Core.Configuration import Configuration, Bunch, Collection
+from Core.Configuration import Configuration, Producer, Collection
 from Tools import parse_effective_areas_file
 
 from TestAnalyzer import TestAnalyzer
@@ -25,17 +25,17 @@ class TestConfiguration(Configuration):
                                                           "effAreaMuons_cone04_pfNeuHadronsAndPhotons.txt")
 
     producers = [
-        Bunch(alias='event', prefix='event_', clazz=Event),
-        Bunch(alias='vertices', clazz=Vertices, vertex_collection='offlineSlimmedPrimaryVertices'),
-        Bunch(alias='jets', clazz=Jets, prefix='jet_', jet_collection='slimmedJets',
+        Producer(name='event', prefix='event_', clazz=Event),
+        Producer(name='vertices', clazz=Vertices, vertex_collection='offlineSlimmedPrimaryVertices'),
+        Producer(name='jets', clazz=Jets, prefix='jet_', jet_collection='slimmedJets',
               btag_collections=['pfCombinedInclusiveSecondaryVertexV2BJetTags']),
-        Bunch(alias='puppiJets', clazz=Jets, prefix='puppijet_', jet_collection='slimmedJetsPuppi'),
-        Bunch(alias='muons', clazz=Muons, prefix='muon_', muon_collection='slimmedMuons',
+        Producer(name='puppiJets', clazz=Jets, prefix='puppijet_', jet_collection='slimmedJetsPuppi'),
+        Producer(name='muons', clazz=Muons, prefix='muon_', muon_collection='slimmedMuons',
               vertex_collection='offlineSlimmedPrimaryVertices', effective_areas_R03=muon_effective_areas_R03,
               effective_areas_R04=muon_effective_areas_R04),
-        Bunch(alias='electrons', clazz=Electrons, prefix='electron_', electron_collection='slimmedElectrons',
+        Producer(name='electrons', clazz=Electrons, prefix='electron_', electron_collection='slimmedElectrons',
               effective_areas_R03=electron_effective_areas),
-        Bunch(alias='mets', clazz=METs, prefix='met_', met_collection='slimmedMETs')
+        Producer(name='mets', clazz=METs, prefix='met_', met_collection='slimmedMETs')
     ]
 
     collections = [

--- a/python/runFramework.py
+++ b/python/runFramework.py
@@ -77,10 +77,8 @@ def runAnalysis(input_files, output_name, Njobs=1, jobNumber=1):
     producers = []
     for producer in configuration.producers:
         clazz = producer.clazz
-        alias = producer.alias
         del producer.clazz
-        del producer.alias
-        p = clazz(alias, **producer.__dict__)
+        p = clazz(**producer.__dict__)
         producers.append(p)
 
     import ROOT

--- a/python/runFramework.py
+++ b/python/runFramework.py
@@ -83,16 +83,6 @@ def runAnalysis(input_files, output_name, Njobs=1, jobNumber=1):
         p = clazz(alias, **producer.__dict__)
         producers.append(p)
 
-    for producer in analyzer._producers:
-        exists = next((x for x in producers if isinstance(x, type(producer)) and x._name == producer._name), None) is \
-            not None
-        if exists:
-            print("A %r producer named %r already exists. Skipping." % (producer.__class__.__name__, producer._name))
-            continue
-
-        producers.append(producer)
-
-
     import ROOT
 
     # output

--- a/python/runFramework.py
+++ b/python/runFramework.py
@@ -95,11 +95,7 @@ def runAnalysis(input_files, output_name, Njobs=1, jobNumber=1):
     runnables = producers + [analyzer]
 
     # Collect collections
-    collections = []
-    for collection in configuration.collections:
-        c = {'name': collection.alias, 'type': collection.type, 'input_tag': collection.input_tag}
-        collections.append(c)
-
+    collections = configuration.collections
     for runnable in runnables:
         collections.extend(runnable._collections)
 
@@ -122,7 +118,7 @@ def runAnalysis(input_files, output_name, Njobs=1, jobNumber=1):
 
     # Register collections
     for collection in collections:
-        events.addCollection(collection['name'], collection['type'], collection['input_tag'])
+        events.addCollection(collection.name, collection.type, collection.input_tag)
 
     # Call beginJob
     for runnable in runnables:


### PR DESCRIPTION
@swertz pointed some true issues with the code, so here's a small refactoring.This PR depends on #30, so it must be merge after #30 (so ignore the 1st commit, it comes from #30).

4 things:
- It's no longer possible to register to producer from the analyzer. It must be done in the configuration file. This way, there's only one way to register a producer, so the user does not have to wonder where it should declare something.
- I enforce the usage of the `Collection` class through the code instead of using dictionary. For consistency, `alias` is renamed to `name`.
- The `Bunch` class disappear in favor of the `Producer` class. This class has 3 mandatory arguments, `name`, `clazz` and `prefix` and will pass any other parameters directly to the producer. It also has a `clone` method à la CMSSW to clone a producer configuration.
- Default configuration are now stored inside the producer file to prevent the user for useless copy pasting. Each producer should provides its own default configuration in a global variable named... `default_configuration`. The user can still modify this configuration by cloning the default one and editing the needed fields.
