### PR TITLE
[RFC] Support for categories and cuts

### DIFF
--- a/python/Core/Analyzer.py
+++ b/python/Core/Analyzer.py
@@ -2,11 +2,89 @@ __author__ = 'sbrochet'
 
 from Core.Runnable import Runnable
 
+from pytree import TreeModel, BoolCol
+
+class Cut(object):
+    class Model(TreeModel):
+        cut = BoolCol(default=False)
+
+    def __init__(self, name, description=''):
+        self.name = name
+        self.description = description
+        self.model = Cut.Model.prefix(name + '_')()
+
+    def pass_cut(self):
+        setattr(self.model, self.name + '_cut', True)
+
+    def status(self):
+        return getattr(self.model, self.name + '_cut')
+
+class Category(object):
+    class Model(TreeModel):
+        category = BoolCol(default=False)
+
+    def __init__(self, name, description=''):
+        self.name = name
+        self.description = description
+        self.model = Category.Model.prefix(name + "_")()
+        self.cuts = {}
+        self.in_category = False
+
+    def _test_event_category(self, products):
+        self.in_category = self.event_in_category(products)
+        setattr(self.model, self.name + '_category', self.in_category)
+
+        return self.in_category
+
+    def reset(self):
+        self.model.reset()
+        self.in_category = False
+
+    def event_in_category(self, products):
+        """
+        Test if the current event is in this category
+        :param products: The products produced for this event
+        :return: True if the current event is in this category, False otherwise
+        """
+        raise NotImplementedError('You must implement the event_in_category method')
+
+    def register_cuts(self):
+        raise NotImplementedError('You must implement the register_cuts method')
+
+    def evaluate_cuts(self, products):
+        raise NotImplementedError('You must implement the evaluate_cuts method')
+
+    def new_cut(self, name, description=''):
+        """
+        Register a new cut
+        :param name: The name of the cut
+        :param description: A description of the cut
+        :return: Nothing
+        """
+        if ':' in name:
+            raise NameError('Invalid character in cut name: \':\'')
+
+        self.cuts[name] = Cut(self.name + '_' + name, description)
+
+    def pass_cut(self, name):
+        """
+        Set the status of the cut ``name`` to True
+        :param name: The name of the cut
+        :return:
+        """
+
+        if name not in self.cuts:
+            raise KeyError('The cut %r is not registered. Please call \'new_cut\' from __init__ first.' % name)
+
+        self.cuts[name].pass_cut()
+
 class Analyzer(Runnable):
     """The base class of all user-defined analyzers"""
 
     def __init__(self, **kwargs):
         Runnable.__init__(self)
+
+        self._categories = {}
 
     def analyze(self, event, products):
         """
@@ -17,3 +95,14 @@ class Analyzer(Runnable):
         :return:
         """
         raise NotImplementedError()
+
+    def new_category(self, category):
+        """
+        Register a new category.
+        :param category: An instance of a class deriving from :class:``Category``
+        :return: Nothing
+        """
+        if not issubclass(category.__class__, Category):
+            raise TypeError('`category` must be an instance of a subclass of Category')
+
+        self._categories[category.name] = category

--- a/python/Core/ProductManager.py
+++ b/python/Core/ProductManager.py
@@ -21,6 +21,12 @@ class ProductManager:
 
             return self._instance.__setattr__(item, value)
 
+        def _get_product(self):
+            """
+            :return: Returns a direct reference to the product
+            """
+            return self._instance
+
     def __init__(self, products):
         for product in products:
             self.__dict__[product['name']] = ProductManager.ProductWrapper(product['prefix'], product['instance'])

--- a/python/TestAnalyzer.py
+++ b/python/TestAnalyzer.py
@@ -1,22 +1,50 @@
 __author__ = 'sbrochet'
 
-from Core.Analyzer import Analyzer
+from Core.Analyzer import Analyzer, Category
 from Models.Candidates import Candidates
 
 from ROOT.Math import LorentzVector
 
 class TestAnalyzer(Analyzer):
+    class TwoMuonsCategory(Category):
+        def register_cuts(self):
+            self.new_cut('z_mass', 'Z mass > 5 GeV')
+            self.new_cut('leading_muon_pt', 'Leading muon pT > 10 GeV')
+
+        def event_in_category(self, products):
+            return len(products.muons.p4) > 1
+
+        def evaluate_cuts(self, products):
+            if products.z.p4[0].M() > 5:
+                self.pass_cut('z_mass')
+
+            if products.muons.p4[0].Pt() > 10:
+                self.pass_cut('leading_muon_pt')
+
+    class TwoElectronsCategory(Category):
+        def register_cuts(self):
+            self.new_cut('z_mass', 'Z mass > 5 GeV')
+
+        def event_in_category(self, products):
+            return len(products.electrons.p4) > 1
+
+        def evaluate_cuts(self, products):
+            if products.z.p4[0].M() > 5:
+                self.pass_cut('z_mass')
+
     def __init__(self, **kwargs):
         Analyzer.__init__(self)
 
         self.z = self.produces(Candidates, 'z', 'z_candidate_')
 
-        # Since Jets producer already registers this collection, 'jet' will be set as an alias of 'jets'
         self.uses('vertices', 'std::vector<reco::Vertex>', kwargs['vertex_collection'])
         self.uses('jets', 'std::vector<pat::Jet>', kwargs['jet_collection'])
         self.uses('muons', 'std::vector<pat::Muon>', kwargs['muon_collection'])
         self.uses('electrons', 'std::vector<pat::Electron>', kwargs['electron_collection'])
         self.uses('mets', 'std::vector<pat::MET>', kwargs['met_collection'])
+
+        self.new_category(TestAnalyzer.TwoMuonsCategory('two_muons', 'At least 2 muons category'))
+        self.new_category(TestAnalyzer.TwoElectronsCategory('two_electrons', 'At least 2 electrons category'))
 
     def beginJob(self):
         print("Begin job!")
@@ -29,11 +57,13 @@ class TestAnalyzer(Analyzer):
         if len(event.muons) >= 2:
             p4 = event.muons[0].p4() + event.muons[1].p4()
             products.z.p4.push_back(LorentzVector('ROOT::Math::PtEtaPhiE4D<float>')(p4.Pt(), p4.Eta(), p4.Phi(), p4.E()))
+        elif len(products.electrons.p4) >= 2:
+            p4 = products.electrons.p4[0] + products.electrons.p4[1]
+            products.z.p4.push_back(LorentzVector('ROOT::Math::PtEtaPhiE4D<float>')(p4.Pt(), p4.Eta(), p4.Phi(), p4.E()))
 
         # Access product produced by the Jets producer
         for z in products.z.p4:
             print "Z candidate mass:", z.M()
-        print products.jets.pu_jet_id[0]
 
     def endJob(self):
         print("End job!")

--- a/python/TestAnalyzer.py
+++ b/python/TestAnalyzer.py
@@ -9,7 +9,8 @@ class TestAnalyzer(Analyzer):
     class TwoMuonsCategory(Category):
         def register_cuts(self):
             self.new_cut('z_mass', 'Z mass > 5 GeV')
-            self.new_cut('leading_muon_pt', 'Leading muon pT > 10 GeV')
+            self.new_cut('leading_muon_pt', 'Leading muon pT > 10 GeV', 'muons.p4[0].Pt() > 10')
+            self.new_cut('leading_jet_pt', 'Leading jet pT > 10 GeV')
 
         def event_in_category(self, products):
             return len(products.muons.p4) > 1
@@ -18,8 +19,8 @@ class TestAnalyzer(Analyzer):
             if products.z.p4[0].M() > 5:
                 self.pass_cut('z_mass')
 
-            if products.muons.p4[0].Pt() > 10:
-                self.pass_cut('leading_muon_pt')
+            if products.jets.p4[0].Pt() > 10:
+                self.pass_cut('leading_jet_pt')
 
     class TwoElectronsCategory(Category):
         def register_cuts(self):

--- a/python/Tools.py
+++ b/python/Tools.py
@@ -48,3 +48,34 @@ def parse_effective_areas_file(f):
             binning.add(float(m.group(1)), float(m.group(2)), float(m.group(3)))
 
     return binning
+
+def get_categories(tree):
+    """
+    Read from the tree the list of cuts applied.
+    :param tree: The tree produced by the framework
+    :return: A nested dictionary where the key is the category name, and the value is another dictionary. For this one,
+    the key 'description' is the category description, and the key 'cuts' is a dictionary where cut name is the key and
+    cut description the value.
+    """
+
+    treeCategories = tree.GetUserInfo().FindObject('categories')
+    if not treeCategories:
+        return {}
+
+    categories = {}
+    for category in treeCategories:
+        category = str(category.GetString())
+        name, description = category.split(':', 2)
+        categories[name] = {'description': description, 'cuts': {}}
+
+    treeCuts = tree.GetUserInfo().FindObject('cuts')
+    if not treeCuts:
+        return categories
+
+    for cut in treeCuts:
+        # format of cut should be '<category_name>:<name>:<description>'
+        cut = str(cut.GetString())
+        category_name, name, description = cut.split(':', 3)
+        categories[category_name]['cuts'][name] = description
+
+    return categories

--- a/python/runFramework.py
+++ b/python/runFramework.py
@@ -162,7 +162,7 @@ def runAnalysis(input_files, output_name, Njobs=1, jobNumber=1):
         # Test categories
         for category in analyzer._categories.itervalues():
             if category._test_event_category(product_manager):
-                category.evaluate_cuts(product_manager)
+                category._evaluate_cuts(product_manager)
 
         # To be kept, an event must belong to at least one category
         if len(analyzer._categories) > 0:

--- a/python/runFramework.py
+++ b/python/runFramework.py
@@ -105,14 +105,34 @@ def runAnalysis(input_files, output_name, Njobs=1, jobNumber=1):
     for runnable in runnables:
         createBranches(runnable._products)
 
+    # Create branches in the tree for each registered cut of the analyzer
+    # Store description as a 'user info' list into the tree
+
+    categories_info = ROOT.TObjArray()
+    categories_info.SetName('categories')
+
+    cuts_info = ROOT.TObjArray()
+    cuts_info.SetName('cuts')
+
+    events_saved_per_category = {}
+    for cat_name, category in analyzer._categories.items():
+        categories_info.Add(ROOT.TObjString('%s:%s' % (category.name, category.description)))
+        tree.set_buffer(category.model, create_branches=True, visible=False)
+        category.register_cuts()
+        events_saved_per_category[category.description] = 0
+
+        for cut_name, cut in category.cuts.items():
+            cuts_info.Add(ROOT.TObjString('%s:%s:%s' % (category.name, cut.name, cut.description)))
+            tree.set_buffer(cut.model, create_branches=True, visible=False)
+
+    tree.GetUserInfo().Add(categories_info)
+    tree.GetUserInfo().Add(cuts_info)
+
     # Products manager. Main access point to products from Analyzer
     product_manager = ProductManager([product for x in runnables for product in x._products])
 
     # events iterator, plus configuration of standard collections and producers
     events = AnalysisEvent(files)
-
-    # FIXME: Work on selections
-    #EventSelection.prepareAnalysisEvent(events)
 
     # Register collections
     for collection in collections:
@@ -124,6 +144,7 @@ def runAnalysis(input_files, output_name, Njobs=1, jobNumber=1):
 
     # main event loop
     i = 0
+    events_saved = 0
     t0 = time.time()
     for event in events:
         # printout
@@ -138,8 +159,33 @@ def runAnalysis(input_files, output_name, Njobs=1, jobNumber=1):
 
         analyzer.analyze(event, product_manager)
 
-        # fill the tree
-        tree.Fill(reset=True)
+        # Test categories
+        for category in analyzer._categories.itervalues():
+            if category._test_event_category(product_manager):
+                category.evaluate_cuts(product_manager)
+
+        # To be kept, an event must belong to at least one category
+        if len(analyzer._categories) > 0:
+            keepEvent = False
+            for category_name, category in analyzer._categories.items():
+                if category.in_category:
+                    keepEvent |= True
+                    events_saved_per_category[category.description] += 1
+
+            if keepEvent:
+                tree.Fill(reset=True)
+                events_saved += 1
+            else:
+                tree.reset_branch_values()
+
+        else:
+            tree.Fill(reset=True)
+            events_saved += 1
+
+        for category in analyzer._categories.itervalues():
+            category.reset()
+            for cut in category.cuts.itervalues():
+                cut.model.reset()
 
         i += 1
 
@@ -152,6 +198,14 @@ def runAnalysis(input_files, output_name, Njobs=1, jobNumber=1):
 
     # close the file
     output.Close()
+
+    print('')
+    print('Job done. %d events processed, %d events saved' % (i, events_saved))
+    if len(events_saved_per_category) > 0:
+        print('{:60s} {:20s}'.format('Category', '# events'))
+        print('-' * 81)
+        for name, value in events_saved_per_category.items():
+            print('{:60s} {:<20d}'.format(name, value))
 
 
 runAnalysis(input_files=options.path, output_name=options.outputname, Njobs=options.Njobs, jobNumber=options.jobNumber)


### PR DESCRIPTION
This is a tentative approach to add support for categories and cuts in the framework. I guess this needs at least 3 or 4 :+1: before merging.

First, some definitions. A `category` is how you can classify your event, for example, `semimu`, `diphoton`, `dimuon`, etc. Each `category` has a set of `cuts`, which can be basically anything, like `leading jet pt > 20 GeV`, `3rd muon eta < 1.5`, etc. In the old framework, I guess `category` was channel and `cuts` was category...

An analyzer can register any number of `category`, using the `new_category` function. This function takes only one argument, an instance of a subclass of `Category`.

A `Category` is identified by a name (sort of `ID) and a optional description. User **must** subclass the``Category`` class and override 3 functions:
- `event_in_category`: This function is called automatically by the framework for each event. It should returns `True` if the event belongs in this category, `False` otherwise. For testing, all the products produced by the framework are available as an argument.
- `register_cuts`: This function is called automatically by the framework at the beginning of the job. You should register here all the cuts for this category, using the function `new_cut`.
- `evaluate_cuts`: This function is called automatically for each events. Here you should evaluated all your cuts for this events, and set the state of the passing cuts using the function `pass_cut`. When called, the status of the cut is set to `True`.

To be saved, an event must at least belong to 1 category.

An example is given into the `TestAnalyzer` for two categories, `TwoMuonsCategory` and `TwoElectronsCategory`. Two cuts are registered for the muons, while only one is registered for the electrons.

On the output file, one branch is created per category, storing boolean, `True` if the event belongs to this category, or `False` otherwise. In addition, one branch is created per cut, storing also `True` or `False`.

Meta-data are also stored in the trees. By meta-data I mean categories and cuts name and description. The method `get_categories` retrieve these meta-data from the tree and create a dictionary from these.

I find this design rather modular, but as always, this is opened to discussions. ~~I also plan for future extensions the ability to register cuts as strings, like `pt > 5 and fabs(eta) < 2.5`. It should be fairly easy to do.~~ Latest commit introduces support for cut strings.
