### PR TITLE
Dynamically create one branch per b-tag algo

### DIFF
--- a/python/Core/ProductManager.py
+++ b/python/Core/ProductManager.py
@@ -37,6 +37,32 @@ class ProductManager:
         """ Let it go, let it go!"""
         return self._frozen
 
+    def new_product_branch(self, product, branch_name, clazz):
+        """
+        Add a new branch to an already created product. This adds a new attribute to the product, and create the
+        branch on the output tree
+        :param product: The newly created branch will be added to this product
+        :param branch_name: The new name of the branch. It'll be prefixed by the product's prefix
+        :param clazz: The class of the new branch.
+        :return:
+        """
+        if self._frozen:
+            raise RuntimeError('You can\'t add a new branch to the tree if its frozen (Fill has already been '
+                               'called once)')
+
+        branch_name = product._prefix + branch_name
+
+        instance = clazz()
+
+        # Add the new attribute to the product
+        product._get_product()[branch_name] = instance
+
+        # Create the branch on the tree
+        self._tree._create_branch(branch_name, instance)
+
+        # Update the main tree buffer
+        self._tree._buffer[branch_name] = instance
+
     def add_metadata(self, name, value):
         """
         Store a new metadata inside the tree UserInfo

--- a/python/pytree/tree.py
+++ b/python/pytree/tree.py
@@ -184,25 +184,8 @@ class BaseTree(NamedObject):
         if create_branches:
             for name in branches:
                 value = treebuffer[name]
-                if self.has_branch(name):
-                    if ignore_duplicates:
-                        #log.warning(
-                            #"Skipping entry in buffer with the same name "
-                            #"as an existing branch: `{0}`".format(name))
-                        continue
-                    raise ValueError(
-                        "Attempting to create two branches "
-                        "with the same name: `{0}`".format(name))
-                if isinstance(value, Scalar):
-                    self.Branch(name, value,
-                        '{0}/{1}'.format(
-                            name, value.type))
-                elif isinstance(value, Array):
-                    self.Branch(name, value,
-                        '{0}[{2:d}]/{1}'.format(
-                            name, value.type, len(value)))
-                else:
-                    self.Branch(name, value)
+                self._create_branch(name, value, ignore_duplicates=ignore_duplicates)
+
         else:
             for name in branches:
                 value = treebuffer[name]
@@ -224,6 +207,27 @@ class BaseTree(NamedObject):
                     newbuffer[branch] = treebuffer[branch]
             newbuffer.set_objects(treebuffer)
             self.update_buffer(newbuffer, transfer_objects=transfer_objects)
+
+    def _create_branch(self, name, value, ignore_duplicates=False):
+        if self.has_branch(name):
+            if ignore_duplicates:
+                #log.warning(
+                    #"Skipping entry in buffer with the same name "
+                    #"as an existing branch: `{0}`".format(name))
+                return
+            raise ValueError(
+                "Attempting to create two branches "
+                "with the same name: `{0}`".format(name))
+        if isinstance(value, Scalar):
+            self.Branch(name, value,
+                '{0}/{1}'.format(
+                    name, value.type))
+        elif isinstance(value, Array):
+            self.Branch(name, value,
+                '{0}[{2:d}]/{1}'.format(
+                    name, value.type, len(value)))
+        else:
+            self.Branch(name, value)
 
     def activate(self, branches, exclusive=False):
         """


### PR DESCRIPTION
Add the ability to dynamically create new branches until the first tree fill occur. This is used in the jet producer to create one branch per b-tag algorithm instead of storing a map of string, float, which duplicate the b-tag algo name for each jet and each event.
